### PR TITLE
Some improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,10 @@
     </section>
 
     <section class="main-content">
-			<p>Questa è la pagina ufficiale dell'evento FirefoxOS Afternoon del 29 Aprile 2015 organizzato da <a href="https://github.com/aroblu94">Aronne Brivio</a> e <a href="https://github.com/nicokant94">Niccolò Cantù</a>.
-			<br>In questa pagina potrete trovare gli strumenti utilizzati durante l'incontro ed alcuni link utili.</p>
+			<p>Questa è la pagina ufficiale dell'evento settimanale FirefoxOS Afternoon organizzato da <a href="https://github.com/aroblu94">Aronne Brivio</a> e <a href="https://github.com/nicokant94">Niccolò Cantù</a> 
+			che si terrà ogni mercoledì pomeriggio presso l'Università degli Studi di Milano (<a href="https://www.google.it/maps/place/Universit%C3%A0+Degli+Studi+Di+Milano,+Didatteca+Venezian/@45.474331,9.233157,17z/data=!3m1!4b1!4m2!3m1!1s0x4786c6f55bf0bda3:0x5c6315f3f26c5faa" target="_blank">ottieni le indicazioni</a>).
+			<br>Il primo incontro si è tenuto il 29 maggio 2015, <a href="http://firefoxmilano.altervista.org/firefoxos-afte…primo-incontro/" target="_blank">qui</a> potete trovarne la relazione.</p>
+			<p>In questa trovate gli strumenti utilizzati durante gli incontri ed alcuni link utili.</p>
 
 			<h3>
 				<a aria-hidden="true">
@@ -30,9 +32,6 @@
 				</li>
 				<li>
 					<a href="https://ftp.mozilla.org/pub/mozilla.org/labs/fxos-simulator/" target="_blank">FirefoxOS Simulator</a> - Add-on per Firefox che installa il simulatore di FirefoxOS sul proprio pc.
-				</li>
-				<li>
-					<a href="https://gobby.github.io/" target="_blank">Gobby</a> - Gobby è un editor collaborativo, che permette di lavorare sugli stessi file contemporaneamente.
 				</li>
 				<li>
 					<a href="https://developer.mozilla.org/it/docs/Tools/WebIDE" target="_blank">WebIDE (Istruzioni per l'utilizzo)</a> - Ambiente di editing e sviluppo applicazioni per FIrefoxOS.
@@ -83,7 +82,7 @@
 			
       <footer class="site-footer">
         <span class="site-footer-owner">
-        	<a href="https://github.com/FFMilan/FirefoxOS-Afternoon" target="_blank">Firefoxos-afternoon</a> is maintained by <a href="https://github.com/FFMilan" target="_blank">FFMilan</a>. 
+        	<a href="https://github.com/FFMilan/FirefoxOS-Afternoon" target="_blank">Firefoxos-afternoon</a> è mantenuto da <a href="https://github.com/FFMilan" target="_blank">FFMilan</a>. Sito ufficiale <a href="firefoxmilano.altervista.org" target="_blank">qui</a>.
         </span>
       </footer>
     </section>


### PR DESCRIPTION
- FirefoxOS Afternoon is now a weekly event, so updated the page
- Added location and link to Google Maps
- Added link to the article about the first meeting
- Removed Gobby
- Added link to Firefox Club Milano in the footer
- Footer translated
